### PR TITLE
Enable ISO8601

### DIFF
--- a/lib/insert-timestamp.coffee
+++ b/lib/insert-timestamp.coffee
@@ -27,4 +27,4 @@ module.exports = InsertTimestamp =
 
   tISO8601: ->
     editor = atom.workspace.getActivePaneItem()
-    editor.insertText(Date.parse(new Date()).toString("yyyy'-'MM'-'dd'T'HH':'mm':'ss"))
+    editor.insertText(new Date().toISOString())

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
   "activationCommands": {
     "atom-workspace": "insert-timestamp:tunix",
     "atom-workspace": "insert-timestamp:tpython",
-    "atom-workspace": "insert-timestamp:DateT"
+    "atom-workspace": "insert-timestamp:DateT",
+    "atom-workspace": "insert-timestamp:ISO8601"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Enables the `insert-timestamp:ISO8601` command and uses the built-in `Date.prototype.toISOString()` method to produce a valid ISO8601 string.